### PR TITLE
Fixing issue with last-round win resulting in a tie

### DIFF
--- a/Tic-Tac-Toe/tic-tac-toe.py
+++ b/Tic-Tac-Toe/tic-tac-toe.py
@@ -22,20 +22,23 @@ class TicTacToeGame:
                 board.submit_move(human, human_move)
                 board.print_board()
                 
-                if board.check_is_tie():
-                    print("It's a tie! 👍 Try again.")
-                    break
-                elif board.check_is_game_over(human, human_move):
+                # if human won
+                if board.check_is_game_over(human, human_move):
                     print("Awesome. You won the game! 🎉")
                     break
-                else:
+                else:  # computer moves
                     computer_move = computer.get_move()
                     board.submit_move(computer, computer_move)
                     board.print_board()
-                    
+                    # if computer won
                     if board.check_is_game_over(computer, computer_move):
                         print("Oops...😨 The computer won. Try again.")
                         break
+                    elif board.check_is_tie():
+                        print("It's a tie! 👍 Try again.")
+                        break
+                    else:
+                        continue
             
             play_again = input("Would you like to play again? Enter X for YES or O for NO: ").upper()
             


### PR DESCRIPTION
In the current implementation of the game, if the board is almost full, there is only one move left, and the final move is the winning move, the game will show that the result was a tie.

... Previous steps.
 
```
Positions:
| 1 | 2 | 3 |
| 4 | 5 | 6 |
| 7 | 8 | 9 |
Board:
| X |   | X |
| O | X | O |
| O | X | O |
 
Please enter your move (1-9): 2
 
Positions:
| 1 | 2 | 3 |
| 4 | 5 | 6 |
| 7 | 8 | 9 |
Board:
| X | X | X |
| O | X | O |
| O | X | O |
 
It's a tie! 👍 Try again.
```
This PR is to fix the functionality by checking if the player or the computer won the game before checking if there was a tie.
